### PR TITLE
Add getFileDestinationUrl endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,49 @@ An example custom policy:
 npm start
 ```
 
+4. Check health.
+
+```
+curl localhost:3000/api/health
+```
+
+Should output:
+
+```
+{"status":"available","message":"OK"}
+```
+
+## Endpoints
+
+### GET /api/health
+#### Input
+No inputs.
+
+#### Output
+Returns a health check.
+
+- `status`: either `available` or `unavailable`.
+- `message`: a more detailed explanation about the health status.
+
+### POST /api/fileDestinationUrl
+#### Input
+##### Required
+
+- `bucket`: the AWS S3 bucket the file will be passed to (e.g. `permanent-local`).
+- `fileType`: the mime type of the file being uploaded (e.g. `image/png`),
+- `maxSize`: the maximum file size that the destination should accept,
+
+##### Optional
+
+- `fileName`: the destination file name within the bucket.
+- `path`: the destination path within the bucket.
+
+#### Output
+- `destinationUrl`: the URL that will ultimately hold the file once it has been uploaded.
+- `presignedPost`: an AWS S3 presigned post which will accept the file.  This post will contain:
+  - `url`: the URL that the file should be POSTed to.
+  - `fields`: an array of fields which must be submitted as part of the POST body. These fields must appear before the file content itself.
+
 ## Contributing
 
 Contributors to this repository agree to adhere to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). To report violations, get in touch with engineers@permanent.org.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ This service does not process files, but provides the information necessary to t
 ## Structure
 
 ```
-- src // The code
+- docs         // API documentation
+- src
+|- controllers // maps between routes to services
+|- routes      // endpoint definitions
+|- services    // business logic
 ```
 
 ## Usage
@@ -18,7 +22,29 @@ This service does not process files, but provides the information necessary to t
 npm install
 ```
 
-2. Start the project.
+2. [Configure AWS credentials.](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html)
+
+These credentials should be associated with an account that has `s3:PutObject` access to the bucket objects you would like API clients to be able to write to.
+
+An example custom policy:
+
+```
+{
+    "Statement": [
+        {
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::MyBucketNameGoesHere/*"
+            ]
+        }
+    ]
+}
+```
+
+3. Start the project.
 
 ```
 npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,6 +1219,37 @@
         }
       }
     },
+    "@hapi/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+    },
+    "@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1750,6 +1781,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
@@ -1989,6 +2026,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.10.tgz",
+      "integrity": "sha512-xAgkb2CMWUMCyVc/3+7iQfOEBE75NvuZeezvmixbUw3nmENf2tCnQkW5yQLTYqvXUQ+R6EXxdqKKbal2zM5V/g==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.10.tgz",
+      "integrity": "sha512-Xt8TbEyZTnD5Xulw95GLMOkmjGICrOQyJ2jqgkSjAUR3mm7pAIzSR0NFBaMcwlzVvlpCjNwbATcWWwjNiZiFrQ==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/uuid": {
       "version": "8.3.0",
@@ -3040,6 +3096,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -4174,6 +4236,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
@@ -4373,6 +4441,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -5982,6 +6056,18 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "joi": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.1.tgz",
+      "integrity": "sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==",
+      "requires": {
+        "@hapi/address": "^4.1.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -7907,7 +7993,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7944,6 +8029,71 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-5.0.0.tgz",
+      "integrity": "sha512-2JAWpPrUOZF4hHH5ZTCN2xjKXvJS3AEwPNXl0HUseHsfcXFvMy9kcsufIHCNAmQ5hlGCvgeAqaR5PBEouN3hlQ==",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "6.1.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -8367,8 +8517,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1990,6 +1990,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -2355,6 +2361,29 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.763.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.763.0.tgz",
+      "integrity": "sha512-uHb+yfsH21wR8ZInj/GQwxCmWJjrL3sOwqwZ2lf9hDxh1P0lsMKDjf0e+8ICgRBY4x28XNWXs3/O15EID6Rsqw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2515,6 +2544,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2651,6 +2685,16 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -3724,6 +3768,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -4631,6 +4680,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -4997,8 +5051,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5924,6 +5977,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6934,6 +6992,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7302,6 +7365,11 @@
         "minimist": "^1.1.1",
         "walker": "~1.0.5"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "saxes": {
       "version": "5.0.1",
@@ -8273,6 +8341,22 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -8294,9 +8378,7 @@
     "uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -8537,6 +8619,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": ">=12.0"
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "node": ">=12.0"
   },
   "dependencies": {
+    "aws-sdk": "^2.763.0",
     "body-parser": "^1.19.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
@@ -37,6 +39,7 @@
     "@tsconfig/node12": "^1.0.7",
     "@types/express": "^4.17.8",
     "@types/jest": "^26.0.13",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "eslint": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "aws-sdk": "^2.763.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "joi": "^17.2.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "@tsconfig/node12": "^1.0.7",
     "@types/express": "^4.17.8",
     "@types/jest": "^26.0.13",
+    "@types/supertest": "^2.0.10",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
@@ -47,6 +49,7 @@
     "eslint-config-airbnb-typescript": "^10.0.0",
     "eslint-plugin-import": "^2.22.0",
     "jest": "^26.4.2",
+    "supertest": "^5.0.0",
     "ts-jest": "^26.3.0",
     "typescript": "^4.0.2"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import { apiRoutes } from './routes';
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/api', apiRoutes);
+export {
+  app,
+};

--- a/src/controllers/fileDestinationUrl.controller.ts
+++ b/src/controllers/fileDestinationUrl.controller.ts
@@ -1,23 +1,27 @@
 import type { Request, Response } from 'express';
+import type { CreateFileDestinationUrlParams } from '../services/fileDestinationUrl.service';
 import { fileDestinationUrlService } from '../services';
+import { validateCreateFileDestinationUrlParams } from '../validators';
+import { serializeError } from '../utils';
 
 interface CreateFileDestinationRequest extends Request {
-  body: {
-    bucket: string;
-    fileName: string;
-    fileType: string;
-    maxSize: number;
-    path: string;
-  };
+  body: CreateFileDestinationUrlParams;
 }
 
 const createFileDestinationUrl = (
   req: CreateFileDestinationRequest,
   res: Response,
 ): void => {
-  fileDestinationUrlService.createFileDestinationUrl(req.body)
-    .then((data) => res.json(data))
-    .catch((err) => res.status(500).json(err));
+  const validation = validateCreateFileDestinationUrlParams(req.body);
+  if (validation.error) {
+    res.status(400).json({ error: validation.error });
+  } else {
+    fileDestinationUrlService.createFileDestinationUrl(req.body)
+      .then((data) => res.json(data))
+      .catch((err) => res.status(500).json({
+        error: serializeError(err),
+      }));
+  }
 };
 
 export const fileDestinationUrlController = {

--- a/src/controllers/fileDestinationUrl.controller.ts
+++ b/src/controllers/fileDestinationUrl.controller.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from 'express';
+import { fileDestinationUrlService } from '../services';
+
+interface CreateFileDestinationRequest extends Request {
+  body: {
+    bucket: string;
+    fileName: string;
+    fileType: string;
+    maxSize: number;
+    path: string;
+  };
+}
+
+const createFileDestinationUrl = (
+  req: CreateFileDestinationRequest,
+  res: Response,
+): void => {
+  fileDestinationUrlService.createFileDestinationUrl(req.body)
+    .then((data) => res.json(data))
+    .catch((err) => res.status(500).json(err));
+};
+
+export const fileDestinationUrlController = {
+  createFileDestinationUrl,
+};

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -4,14 +4,17 @@ import type {
   Response,
 } from 'express';
 import { healthService } from '../services';
+import { serializeError } from '../utils';
 
 const getHealth: Handler = (
   req: Request,
   res: Response,
 ): void => {
-  res.json({
-    status: healthService.getHealth(),
-  });
+  healthService.getHealth()
+    .then((data) => res.json(data))
+    .catch((err) => res.status(500).json({
+      error: serializeError(err),
+    }));
 };
 
 export const healthController = {

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export { healthController } from './health.controller';
+export { fileDestinationUrlController } from './fileDestinationUrl.controller';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,3 @@
-import express from 'express';
-import bodyParser from 'body-parser';
-import { apiRoutes } from './routes';
+import { app } from './app';
 
-const app = express();
-app.use(bodyParser.json());
-app.use('/api', apiRoutes);
 app.listen(process.env.PORT ?? 3000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
+import bodyParser from 'body-parser';
 import { apiRoutes } from './routes';
 
 const app = express();
+app.use(bodyParser.json());
 app.use('/api', apiRoutes);
 app.listen(process.env.PORT ?? 3000);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,10 @@
 import express from 'express';
-import { healthController } from '../controllers';
+import {
+  fileDestinationUrlController,
+  healthController,
+} from '../controllers';
 
 const apiRoutes = express.Router();
 apiRoutes.get('/health', healthController.getHealth);
-
+apiRoutes.post('/fileDestinationUrl', fileDestinationUrlController.createFileDestinationUrl);
 export { apiRoutes };

--- a/src/services/fileDestinationUrl.service.ts
+++ b/src/services/fileDestinationUrl.service.ts
@@ -1,0 +1,69 @@
+import { S3 } from 'aws-sdk';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface CreateFileDestinationUrlParams {
+  bucket: string;
+  fileName: string;
+  fileType: string;
+  maxSize: number;
+  path: string;
+}
+
+export interface CreateFileDestinationUrlResponse {
+  destinationUrl: string;
+  presignedPost: S3.PresignedPost;
+}
+
+/**
+ * This helper method will generate a presigned post.
+ *
+ * @param  {S3.PresignedPost.Params}   s3Params The parameters to pass to S3.
+ * @return {Promise<S3.PresignedPost>}          The resulting presigned post.
+ */
+const createPresignedPost = async (
+  s3Params: S3.PresignedPost.Params,
+): Promise<S3.PresignedPost> => {
+  const s3 = new S3();
+  // This does NOT use the callback variation of createPresignedPost due to a bug in the aws sdk.
+  // The downside is that this means credentials cannot be provided via IAM, and must be provided
+  // directly. Once the sdk bug is fixed, we would like to use the callback approach.
+  // https://github.com/aws/aws-sdk-js/issues/3486
+  //
+  // When we do eventually implement the callback approach, please note this additional bug:
+  // The callback types need to be manually overridden to allow for null as well as Error, due
+  // to a bug in the AWS SDK type definitions.
+  // https://github.com/aws/aws-sdk-js/issues/3055
+  return new Promise<S3.PresignedPost>((resolve) => {
+    resolve(s3.createPresignedPost(s3Params));
+  });
+};
+
+const createFileDestinationUrl = async ({
+  bucket,
+  fileType,
+  maxSize,
+  fileName = '',
+  path = '',
+}: CreateFileDestinationUrlParams): Promise<CreateFileDestinationUrlResponse> => {
+  const key = `${path}/${fileName || uuidv4()}`;
+  const s3Params = {
+    Bucket: bucket,
+    Fields: {
+      Key: key,
+    },
+    Expires: 3600,
+    Conditions: [
+      ['eq', '$Content-Type', fileType],
+      ['content-length-range', 0, maxSize],
+    ],
+  };
+  const presignedPost = await createPresignedPost(s3Params);
+  return {
+    destinationUrl: `https://${bucket}.s3.amazonaws.com/${key}`,
+    presignedPost,
+  };
+};
+
+export const fileDestinationUrlService = {
+  createFileDestinationUrl,
+};

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -1,9 +1,38 @@
-enum HealthStatus {
+import { STS } from 'aws-sdk';
+
+export enum HealthStatus {
   AVAILABLE = 'available',
   UNAVAILABLE = 'unavailable',
 }
 
-const getHealth = (): HealthStatus => HealthStatus.AVAILABLE;
+export interface HealthReport {
+  status: HealthStatus;
+  message: string;
+}
+
+const getCallerIdentity = async (): Promise<STS.GetCallerIdentityResponse> => {
+  const sts = new STS();
+  return sts.getCallerIdentity().promise();
+};
+
+const getHealth = async (): Promise<HealthReport> => {
+  try {
+    await getCallerIdentity();
+  } catch (err: unknown) {
+    let message = 'unknown error';
+    if (err instanceof Error) {
+      message = err.message;
+    }
+    return {
+      status: HealthStatus.UNAVAILABLE,
+      message: `Could not get a caller identity (${message})`,
+    };
+  }
+  return {
+    status: HealthStatus.AVAILABLE,
+    message: 'OK',
+  };
+};
 
 export const healthService = {
   getHealth,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
 export { healthService } from './health.service';
+export { fileDestinationUrlService } from './fileDestinationUrl.service';

--- a/src/tests/__snapshots__/fileDestinationUrlApi.int.test.ts.snap
+++ b/src/tests/__snapshots__/fileDestinationUrlApi.int.test.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fileDestinationUrl API #int POST /api/fileDestinationUrl should return an S3 URL when passed the proper parameters 1`] = `
+Object {
+  "destinationUrl": "https://permanent-tests.s3.amazonaws.com/my_example_path/example.png",
+}
+`;
+
+exports[`fileDestinationUrl API #int POST /api/fileDestinationUrl should specify all validation details when passed a negative maxSize 1`] = `
+Object {
+  "error": Object {
+    "_original": Object {
+      "maxSize": -1,
+    },
+    "details": Array [
+      Object {
+        "context": Object {
+          "key": "bucket",
+          "label": "bucket",
+        },
+        "message": "\\"bucket\\" is required",
+        "path": Array [
+          "bucket",
+        ],
+        "type": "any.required",
+      },
+      Object {
+        "context": Object {
+          "key": "fileType",
+          "label": "fileType",
+        },
+        "message": "\\"fileType\\" is required",
+        "path": Array [
+          "fileType",
+        ],
+        "type": "any.required",
+      },
+      Object {
+        "context": Object {
+          "key": "maxSize",
+          "label": "maxSize",
+          "limit": 1,
+          "value": -1,
+        },
+        "message": "\\"maxSize\\" must be greater than or equal to 1",
+        "path": Array [
+          "maxSize",
+        ],
+        "type": "number.min",
+      },
+    ],
+  },
+}
+`;
+
+exports[`fileDestinationUrl API #int POST /api/fileDestinationUrl should specify all validation details when passed no parameters 1`] = `
+Object {
+  "error": Object {
+    "_original": Object {},
+    "details": Array [
+      Object {
+        "context": Object {
+          "key": "bucket",
+          "label": "bucket",
+        },
+        "message": "\\"bucket\\" is required",
+        "path": Array [
+          "bucket",
+        ],
+        "type": "any.required",
+      },
+      Object {
+        "context": Object {
+          "key": "fileType",
+          "label": "fileType",
+        },
+        "message": "\\"fileType\\" is required",
+        "path": Array [
+          "fileType",
+        ],
+        "type": "any.required",
+      },
+      Object {
+        "context": Object {
+          "key": "maxSize",
+          "label": "maxSize",
+        },
+        "message": "\\"maxSize\\" is required",
+        "path": Array [
+          "maxSize",
+        ],
+        "type": "any.required",
+      },
+    ],
+  },
+}
+`;

--- a/src/tests/fileDestinationUrlApi.int.test.ts
+++ b/src/tests/fileDestinationUrlApi.int.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import { app } from '../app';
+
+jest.mock('aws-sdk');
+
+describe('fileDestinationUrl API #int', () => {
+  const agent = request(app);
+  describe('POST /api/fileDestinationUrl', () => {
+    it('should specify all validation details when passed no parameters', async () => {
+      const response = await agent
+        .post('/api/fileDestinationUrl')
+        .expect(400);
+
+      expect(response.body).toMatchSnapshot();
+    });
+
+    it('should specify all validation details when passed a negative maxSize', async () => {
+      const response = await agent
+        .post('/api/fileDestinationUrl')
+        .send({
+          maxSize: -1,
+        })
+        .expect(400);
+
+      expect(response.body).toMatchSnapshot();
+    });
+
+    it('should return an S3 URL when passed the proper parameters', async () => {
+      const response = await agent
+        .post('/api/fileDestinationUrl')
+        .send({
+          bucket: 'permanent-tests',
+          path: 'my_example_path',
+          fileType: 'image/png',
+          fileName: 'example.png',
+          maxSize: 5000000,
+        })
+        .expect(200);
+
+      expect(response.body).toMatchSnapshot();
+    });
+  });
+});

--- a/src/tests/healthApi.int.test.ts
+++ b/src/tests/healthApi.int.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import type { HealthReport } from '../services/health.service';
+import { app } from '../app';
+
+interface GetHealthApiResponse {
+  body: HealthReport;
+}
+
+interface MockGetCallerIdentity {
+  promise: jest.Mock;
+}
+
+interface MockSTS {
+  getCallerIdentity: () => MockGetCallerIdentity;
+}
+
+// Note: Jest requires this variable to be prefixed with `mock` in order for us to use it
+// as the mocked return value of the STS constructor.  Failure to comply will cause Jest to
+// complain about out-of-scope variables.
+// The reason we need to define it here is so that we can manipulate the mock implementation
+// output in our tests.
+const mockGetCallerIdentityPromise = jest.fn();
+jest.mock('aws-sdk', () => ({
+  STS: jest.fn().mockImplementation(
+    (): MockSTS => ({
+      getCallerIdentity: (): MockGetCallerIdentity => ({
+        promise: mockGetCallerIdentityPromise,
+      }),
+    }),
+  ),
+}));
+
+const agent = request(app);
+
+describe('health API #int', () => {
+  describe('GET /api/health', () => {
+    it('should return an unavailable status if AWS cannot generate an identity', async () => {
+      mockGetCallerIdentityPromise.mockRejectedValueOnce(new Error('simulated failure'));
+      const response: GetHealthApiResponse = await agent
+        .get('/api/health');
+
+      expect(response.body.status).toBe('unavailable');
+      expect(response.body.message).toMatch(/simulated failure/);
+    });
+
+    it('should return an available status if AWS can generate an identity', async () => {
+      mockGetCallerIdentityPromise.mockResolvedValueOnce('ok');
+      const response: GetHealthApiResponse = await agent
+        .get('/api/health');
+      expect(response.body.status).toBe('available');
+    });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,17 @@
+interface SerializedError {
+  details: {
+    message: string;
+    type: string;
+  };
+}
+
+const serializeError = (err: Error): SerializedError => ({
+  details: {
+    message: err.message,
+    type: err.name,
+  },
+});
+
+export {
+  serializeError,
+};

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,0 +1,1 @@
+export { validateCreateFileDestinationUrlParams } from './validateCreateFileDestinationUrlParams';

--- a/src/validators/validateCreateFileDestinationUrlParams.ts
+++ b/src/validators/validateCreateFileDestinationUrlParams.ts
@@ -1,0 +1,15 @@
+import Joi from 'joi';
+import type { CreateFileDestinationUrlParams } from '../services/fileDestinationUrl.service';
+
+export const validateCreateFileDestinationUrlParams = (
+  data: CreateFileDestinationUrlParams,
+): Joi.ValidationResult => Joi.object().keys({
+  bucket: Joi.string().min(3, 'utf8').max(63, 'utf8').required(),
+  fileName: Joi.string().max(1024, 'utf8'),
+  fileType: Joi.string().required(),
+  maxSize: Joi.number().min(1).required(),
+  path: Joi.string(),
+}).validate(
+  data,
+  { abortEarly: false },
+);


### PR DESCRIPTION
## Description
This PR adds a `POST /api/getFileDestinationUrl` endpoint to the service, which can be used to generate a signed S3 request.

Resolves #7 

## Steps to Test
- Install new dependencies (`npm i`)
- Configure AWS credentials with write access to an S3 bucket.
- POST to the new endpoint; the post body must include a `bucket` and a `fileType` parameter.
- The API should return information that can then be used to POST your uploaded file directly to S3.

You can also run the integration tests:

- `npm test`