### PR TITLE
Upload package to all 3 environment dirs on S3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,6 @@ jobs:
             - name: Copy package to S3
               run: |
                 aws s3 cp ../upload-service.tar.gz s3://permanent-repos/dev/upload-service.tar.gz
+                aws s3 cp ../upload-service.tar.gz s3://permanent-repos/staging/upload-service.tar.gz
+                aws s3 cp ../upload-service.tar.gz s3://permanent-repos/prod/upload-service.tar.gz
 


### PR DESCRIPTION
Now that I'm rolling out the new staging environment, the new deployment script expects this package to be present in the correct directory on S3. Since there are no specific per-env build actions, simply upload the tar ball to the `dev`, `staging` and `prod` directories on every push to main. This only deploys the package to newly-built AMIs. For all other deploys, the `deploy` Github action in the infrastructure repository must be triggered.