### PR TITLE
Remove `--production` flag from `npm install`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
               with:
                 node-version: '10.x'
                 registry-url: 'https://npm.pkg.github.com'
-            - run: npm install --production
+            - run: npm install
             - name: Create a tar archive
               run: |
                 cd ..

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
                 node-version: '10.x'
                 registry-url: 'https://npm.pkg.github.com'
             - run: npm install
+            - run: npm run build
+            - run: npm prune --production
             - name: Create a tar archive
               run: |
                 cd ..

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,10 @@ jobs:
                 registry-url: 'https://npm.pkg.github.com'
             - run: npm install
             - run: npm run build
-            - run: npm prune --production
             - name: Create a tar archive
               run: |
                 cd ..
-                tar --exclude=.git* -czvf upload-service.tar.gz upload-service
+                tar --exclude=.git* --exclude=node_modules/* --exclude=src/* -czvf upload-service.tar.gz upload-service
             - name: Configure AWS Credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:


### PR DESCRIPTION
As written, the service runs using `babel-node` directly from the TypeScript source. Babel is currently listed under `devDependencies` and isn't installed using the `--production` flag. For now, we won't change this, and will just remove this flag so that all dependencies get installed for the `tar` that gets created.

Potentially in the future, we could adjust this configuration to run from transpiled Javascript using `node` directly, but in the interest of making the minimum change, this is the approach I think we should take.