### PR TITLE
Add attribution for contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "name": "Cristina Muñoz"
     },
     {
-      "name": "Andrew Atwood"
+      "name": "Andrew Atwood",
+      "email": "aatwood@permanent.org"
     }
   ],
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,30 @@
   "publishConfig": {
     "registry":"https://npm.pkg.github.com/PermanentOrg"
   },
-  "author": "Permanent.org",
+  "author": {
+    "name": "Permanent.org",
+    "email": "engineers@permanent.org",
+    "url": "https://www.permanent.org/"
+  },
+  "contributors": [
+    {
+      "name": "Dan Schultz"
+    },
+    {
+      "name": "Mithuna Krishna"
+    },
+    {
+      "name": "Jason Owen",
+      "email": "jasonaowen@opentechstrategies.com",
+      "url": "https://jasonaowen.net"
+    },
+    {
+      "name": "Cristina Muñoz"
+    },
+    {
+      "name": "Andrew Atwood"
+    }
+  ],
   "license": "AGPL-3.0",
   "bugs": {
     "url": "https://github.com/PermanentOrg/upload-service/issues"


### PR DESCRIPTION
The folks at Permanent want to give more credit to the humans involved in writing this software. npm gives us the tools to do so: the [contributors](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#people-fields-author-contributors) field. List everyone who has worked on this repository, in approximately date order.

@slifty, @mithuna, @xmunoz, and @andrewatwood: are you okay with being listed here? Do you want to include an email address and/or website?