### PR TITLE
Test against Node.js 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         node:
           - '12'
+          - '14'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
The 14.x release series of Node.js is the active long-term-support line. We are currently using Node.js 12 in production, which is in maintenance LTS, and is planned to be out of maintenance on 2022-04-30; we will need to upgrade before that end-of-life date.

Start testing against Node.js 14, so that we can make sure we're ready to upgrade once we've verified that everything is compatible.

The first step of the upgrade is to see if the build for this PR passes; if it does not, then we'll have more work to do for #27.

Issue #27 Upgrade to Node 14
Follow-up to PR #26 Build and test only on Node 12