### PR TITLE
Dockerize upload service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+!templates/.aws

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+export AWS_ACCESS_KEY_ID="tHiSiSyOuRAcCeSsKeY"
+export AWS_ACCESS_SECRET="tHiSiSyOuRAcCeSsSeCrEt"
+export AWS_REGION=us-west-2

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+              "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}"
+              "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+              "AWS_DEFAULT_REGION=${{ secrets.AWS_DEFAULT_REGION }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:12-alpine
+
+LABEL name="upload-service" version="1.0" maintainer="Permanent Legacy Foundation <https://permanent.org>"
+
+RUN apk add gettext
+
+WORKDIR /src
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN mv ./templates/.aws /root/.aws
+
+RUN envsubst < "/root/.aws/credentials" | tee "/root/.aws/credentials"
+
+RUN envsubst < "/root/.aws/config" | tee "/root/.aws/config"
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Should output:
 {"status":"available","message":"OK"}
 ```
 
+## Running with Docker
+
+- `cp .env.example .env` and set correct AWS credentials
+- `docker-compose up` or `sudo docker-compose up --build` to force rebuild after first run.
+- See [http://localhost:3000/api/health](http://localhost:3000/api/health)
+
 ## Endpoints
 
 ### GET /api/health

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  upload-service:
+    build: .
+    volumes:
+      - .:/src
+    command: npm run start
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+      DEBUG: nodejs-docker-express:*
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REGION: ${AWS_REGION}

--- a/templates/.aws/config
+++ b/templates/.aws/config
@@ -1,0 +1,5 @@
+[default]
+output = json
+region = "${AWS_REGION}"
+[preview]
+cloudfront = true

--- a/templates/.aws/credentials
+++ b/templates/.aws/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = "${AWS_ACCESS_KEY_ID}"
+aws_secret_access_key = "${AWS_ACCESS_SECRET}"


### PR DESCRIPTION
 Dockerize upload service

This commit adds a Dockerfile along with a
`docker-compose` file which sets up the upload service
to run on localhost:3000

Additionally, it adds:

- The `templates` directory which holds
the `.aws` template files

- An `.env.example` that is used
to hold environment variables for `docker-compose`

- A `.dockerignore` to prevent docker from ignoring
the hidden `template/.aws` directory