### PR TITLE
Upgrade to Node 16

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "16"
       - run: npm install
       - run: npm run build
       - name: Create a tar archive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - '14'
-          - '16'
+          - "16"
+          - "18"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@babel/node": "^7.22.6",
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.5",
-        "@tsconfig/node14": "^14.1.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^26.0.22",
         "@types/supertest": "^2.0.10",
@@ -4972,12 +4971,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
-      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
-      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/node": "^7.22.6",
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.5",
+        "@tsconfig/node16": "^16.1.1",
         "@types/express": "^4.17.17",
         "@types/jest": "^26.0.22",
         "@types/supertest": "^2.0.10",
@@ -4971,6 +4972,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
+      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.14",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://permanent.org",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=16.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.395.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@babel/node": "^7.22.6",
     "@babel/preset-env": "^7.22.10",
     "@babel/preset-typescript": "^7.22.5",
-    "@tsconfig/node14": "^14.1.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^26.0.22",
     "@types/supertest": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/node": "^7.22.6",
     "@babel/preset-env": "^7.22.10",
     "@babel/preset-typescript": "^7.22.5",
+    "@tsconfig/node16": "^16.1.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^26.0.22",
     "@types/supertest": "^2.0.10",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "noEmit": true


### PR DESCRIPTION
Bump the node version to Node 16. This doesn't require changes to installed packages outside of `tsconfig`, so much of this is just bumping configuration values and updating Github workflows.

Note the versions of Node that the checks for this PR are running on.