### PR TITLE
Update Dockerfile to use node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 
 LABEL name="upload-service" version="1.0" maintainer="Permanent Legacy Foundation <https://permanent.org>"
 


### PR DESCRIPTION
Currently, the Dockerfile in this project uses node 14. This project doesn't support versions of node less than 16, and the node 14 container is failing to correctly install dependencies. To correct this, this commit updates the Dockerfile to use node 18.