### PR TITLE
Enable dependabot action ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR updates our dependabot config so that we get alerted of new versions of the GitHub Actions we use here.

Resolves #519