### PR TITLE
Remove aws-sdk v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.826.0",
+				"@aws-sdk/client-sts": "^3.840.0",
 				"@aws-sdk/s3-presigned-post": "^3.842.0",
 				"@aws-sdk/s3-request-presigner": "^3.828.0",
 				"@sentry/node": "^9.34.0",
-				"aws-sdk": "^2.1692.0",
 				"express": "^5.1.0",
 				"express-winston": "^4.2.0",
 				"joi": "^17.13.3",
@@ -490,6 +490,95 @@
 			"version": "3.840.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
 			"integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+			"dependencies": {
+				"@smithy/types": "^4.3.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts": {
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.840.0.tgz",
+			"integrity": "sha512-h+mu89Wk81Ne+B624GT/pBM5VjuAZueSeQNixhgtQ1QHi6bZzrpz8+lvMSibKO+kXFyQsTLzkyibbxnhLpWQZA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/credential-provider-node": "3.840.0",
+				"@aws-sdk/middleware-host-header": "3.840.0",
+				"@aws-sdk/middleware-logger": "3.840.0",
+				"@aws-sdk/middleware-recursion-detection": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/region-config-resolver": "3.840.0",
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.840.0",
+				"@aws-sdk/util-user-agent-browser": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.840.0",
+				"@smithy/config-resolver": "^4.1.4",
+				"@smithy/core": "^3.6.0",
+				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/hash-node": "^4.0.4",
+				"@smithy/invalid-dependency": "^4.0.4",
+				"@smithy/middleware-content-length": "^4.0.4",
+				"@smithy/middleware-endpoint": "^4.1.13",
+				"@smithy/middleware-retry": "^4.1.14",
+				"@smithy/middleware-serde": "^4.0.8",
+				"@smithy/middleware-stack": "^4.0.4",
+				"@smithy/node-config-provider": "^4.1.3",
+				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/protocol-http": "^5.1.2",
+				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/types": "^4.3.1",
+				"@smithy/url-parser": "^4.0.4",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.21",
+				"@smithy/util-defaults-mode-node": "^4.0.21",
+				"@smithy/util-endpoints": "^3.0.6",
+				"@smithy/util-middleware": "^4.0.4",
+				"@smithy/util-retry": "^4.0.6",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.840.0.tgz",
+			"integrity": "sha512-x3Zgb39tF1h2XpU+yA4OAAQlW6LVEfXNlSedSYJ7HGKXqA/E9h3rWQVpYfhXXVVsLdYXdNw5KBUkoAoruoZSZA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/xml-builder": "3.821.0",
+				"@smithy/core": "^3.6.0",
+				"@smithy/node-config-provider": "^4.1.3",
+				"@smithy/property-provider": "^4.0.4",
+				"@smithy/protocol-http": "^5.1.2",
+				"@smithy/signature-v4": "^5.1.2",
+				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/types": "^4.3.1",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.4",
+				"@smithy/util-utf8": "^4.0.0",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+			"integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -5696,6 +5785,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -5704,35 +5794,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/aws-sdk": {
-			"version": "2.1692.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
-			"integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"buffer": "4.9.2",
-				"events": "1.1.1",
-				"ieee754": "1.1.13",
-				"jmespath": "0.16.0",
-				"querystring": "0.2.0",
-				"sax": "1.2.1",
-				"url": "0.10.3",
-				"util": "^0.12.4",
-				"uuid": "8.0.0",
-				"xml2js": "0.6.2"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/aws-sdk/node_modules/uuid": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-			"integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -5844,25 +5905,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/body-parser": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -5963,16 +6005,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"node_modules/buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-			"dependencies": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -5992,6 +6024,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"dev": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
 				"es-define-property": "^1.0.0",
@@ -6446,6 +6479,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -7404,14 +7438,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/events": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-			"engines": {
-				"node": ">=0.4.x"
-			}
-		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7740,6 +7766,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -8105,6 +8132,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -8142,6 +8170,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -8205,11 +8234,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -8372,21 +8396,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8464,6 +8473,7 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -8564,6 +8574,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
 			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -8735,6 +8746,7 @@
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -8787,11 +8799,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -9713,14 +9720,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/jmespath": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
 		"node_modules/joi": {
 			"version": "17.13.3",
 			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -10451,6 +10450,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -10593,15 +10593,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/querystring": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-			"deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-			"engines": {
-				"node": ">=0.4.x"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -10935,11 +10926,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
-		"node_modules/sax": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-			"integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
-		},
 		"node_modules/semver": {
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -11014,6 +11000,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -12039,32 +12026,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/url": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-			"integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-			"dependencies": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			}
-		},
-		"node_modules/url/node_modules/punycode": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-			"integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12209,6 +12170,7 @@
 			"version": "1.1.19",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
 			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
@@ -12390,26 +12352,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/xml2js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-			"dependencies": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.826.0",
+		"@aws-sdk/client-sts": "^3.840.0",
 		"@aws-sdk/s3-presigned-post": "^3.842.0",
 		"@aws-sdk/s3-request-presigner": "^3.828.0",
 		"@sentry/node": "^9.34.0",
-		"aws-sdk": "^2.1692.0",
 		"express": "^5.1.0",
 		"express-winston": "^4.2.0",
 		"joi": "^17.13.3",

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -1,4 +1,8 @@
-import { STS } from "aws-sdk";
+import {
+	STSClient,
+	GetCallerIdentityCommand,
+	GetCallerIdentityCommandOutput,
+} from "@aws-sdk/client-sts";
 
 export enum HealthStatus {
 	AVAILABLE = "available",
@@ -10,9 +14,10 @@ export interface HealthReport {
 	message: string;
 }
 
-const getCallerIdentity = async (): Promise<STS.GetCallerIdentityResponse> => {
-	const sts = new STS();
-	return sts.getCallerIdentity().promise();
+const getCallerIdentity = async (): Promise<GetCallerIdentityCommandOutput> => {
+	const client = new STSClient({});
+	const command = new GetCallerIdentityCommand({});
+	return await client.send(command);
 };
 
 const getHealth = async (): Promise<HealthReport> => {

--- a/src/tests/healthApi.int.test.ts
+++ b/src/tests/healthApi.int.test.ts
@@ -1,53 +1,46 @@
 import request from "supertest";
-import type { HealthReport } from "../services/health.service";
 import { app } from "../app";
+import { STSClient } from "@aws-sdk/client-sts";
 
-interface GetHealthApiResponse {
-	body: HealthReport;
-}
-
-interface MockGetCallerIdentity {
-	promise: jest.Mock;
-}
-
-interface MockSTS {
-	getCallerIdentity: () => MockGetCallerIdentity;
-}
-
-// Note: Jest requires this variable to be prefixed with `mock` in order for us to use it
-// as the mocked return value of the STS constructor.  Failure to comply will cause Jest to
-// complain about out-of-scope variables.
-// The reason we need to define it here is so that we can manipulate the mock implementation
-// output in our tests.
-const mockGetCallerIdentityPromise = jest.fn();
-jest.mock("aws-sdk", () => ({
-	STS: jest.fn().mockImplementation(
-		(): MockSTS => ({
-			getCallerIdentity: (): MockGetCallerIdentity => ({
-				promise: mockGetCallerIdentityPromise,
-			}),
-		}),
-	),
+jest.mock("@aws-sdk/client-sts");
+const mockSend = jest.fn();
+(STSClient as jest.Mock).mockImplementation(() => ({
+	send: mockSend,
 }));
 
 const agent = request(app);
 
 describe("health API #int", () => {
 	describe("GET /api/health", () => {
-		it("should return an unavailable status if AWS cannot generate an identity", async () => {
-			mockGetCallerIdentityPromise.mockRejectedValueOnce(
-				new Error("simulated failure"),
-			);
-			const response: GetHealthApiResponse = await agent.get("/api/health");
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
 
-			expect(response.body.status).toBe("unavailable");
-			expect(response.body.message).toMatch(/simulated failure/);
+		it("should return an unavailable status if AWS cannot generate an identity", async () => {
+			mockSend.mockRejectedValueOnce(new Error("simulated failure"));
+
+			const response = await agent.get("/api/health");
+
+			expect(response).toMatchObject({
+				body: {
+					status: "unavailable",
+					message: expect.stringMatching(/simulated failure/) as unknown,
+				},
+			});
 		});
 
 		it("should return an available status if AWS can generate an identity", async () => {
-			mockGetCallerIdentityPromise.mockResolvedValueOnce("ok");
-			const response: GetHealthApiResponse = await agent.get("/api/health");
-			expect(response.body.status).toBe("available");
+			mockSend.mockResolvedValueOnce({
+				UserId: "test-user",
+				Account: "123456789012",
+				Arn: "arn:aws:sts::123456789012:user/test-user",
+			});
+
+			const response = await agent.get("/api/health");
+
+			expect(response).toMatchObject({
+				body: { status: "available", message: "OK" },
+			});
 		});
 	});
 });


### PR DESCRIPTION
This PR updates the last spot using the v2 aws sdk to using the v3 version and removes the now-obsolete dependency.

Resolves #83